### PR TITLE
Add error handling for invalid phone numbers

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: 'en-US'
+early_access: true
+reviews:
+    request_changes_workflow: true
+    high_level_summary: true
+    poem: false
+    review_status: true
+    collapse_walkthrough: false
+    profile: assertive
+    tools:
+        markdownlint:
+            enabled: true
+        ast-grep:
+            essential_rules: true
+        github-checks:
+            enabled: true
+            timeout_ms: 90000
+        ruff:
+            enabled: false
+        shellcheck:
+            enabled: true
+    auto_review:
+        enabled: true
+        ignore_title_keywords:
+            - '[skip review]'
+            - 'Automatic PR'
+        drafts: false
+        base_branches:
+            - 'main'
+    path_instructions:
+        - path: '**/*.ts'
+          instructions: 'Review the TypeScript code of the NPM package to ensure it adheres to the principles of awesome and clean code. This includes proper use of functions, classes, modules. Also, ensure the code follows best practices for package development, such as clear and concise documentation, proper error handling, and efficient data structures and algorithms. The code should also conform to the ESLint rules configured in the codebase. Highlight any deviations and suggest appropriate corrections. Using design patterns that promote code reusability and readability is encouraged.'
+        - path: 'test/**/*'
+          instructions: 'Review the test files to ensure they cover all the relevant use cases and edge cases of the codebase. Check for proper test coverage, assertions, and error handling. Ensure that the tests are well-organized, easy to read, and provide meaningful feedback. Highlight any missing or redundant tests and suggest improvements to enhance the overall quality of the test suite.'
+chat:
+    auto_reply: true
+knowledge_base:
+    learnings:
+        scope: auto
+    issues:
+        scope: auto

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 node_modules/
 lib/
-
+coverage/
 
 .DS_Store

--- a/.github/workflows/corveralls.yml
+++ b/.github/workflows/corveralls.yml
@@ -1,0 +1,25 @@
+name: Test Coveralls
+on:
+    pull_request_target:
+        branches: ['*']
+    push:
+        branches: ['*']
+
+jobs:
+    coveralls:
+        name: Coveralls
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+
+            - name: npm install
+              run: |
+                  npm install
+
+            - name: Run tests
+              run: |
+                  npm run test:cov
+
+            - name: Coveralls
+              uses: coverallsapp/github-action@v2

--- a/.github/workflows/test-cov.yml
+++ b/.github/workflows/test-cov.yml
@@ -1,0 +1,24 @@
+name: Test
+on:
+    pull_request_target:
+        branches: ['*']
+    push:
+        branches: ['*']
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        permissions:
+            # Required to checkout the code
+            contents: write
+            checks: write
+            # Required to put a comment into the pull-request
+            pull-requests: write
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - uses: ArtiomTr/jest-coverage-report-action@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN  }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 lib/
+coverage/
 
 .env

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ node_modules
 src
 .gitignore
 .prettierrc
+coverage/
 
 *.md
 !README*.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
 lib/
+coverage/
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# phone-validate
+# @vn-utils/phone-validate
 
 <p align="center">
 <a href="https://www.npmjs.com/package/@vn-utils/phone-validate" target="_blank"><img src="https://img.shields.io/npm/v/@vn-utils/phone-validate" alt="NPM Version" /></a>
 <a href="https://www.npmjs.com/package/@vn-utils/phone-validate" target="_blank"><img src="https://img.shields.io/npm/l/@vn-utils/phone-validate" alt="Package License"><a>
-<a href="https://www.npmjs.com/package/@vn-utils/phone-validate" target="_blank"><img src="https://img.shields.io/npm/dm/@vn-utils/phone-validate" alt="NPM Downloads"></a>
+<a href="https://www.npmjs.com/package/@vn-utils/phone-validate" target="_blank"><img src="https://img.shields.io/npm/d18m/@vn-utils/phone-validate" alt="NPM Downloads"></a>
+<a href='https://coveralls.io/github/lehuygiang28/phone-validate?branch=main'><img src='https://coveralls.io/repos/github/lehuygiang28/phone-validate/badge.svg?branch=main' alt='Coverage Status'/></a>
 </p>
 
 <strong>An open-source library support to validate Vietnamese phone number.</strong>

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,9 @@
 module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
+    coverageThreshold: {
+        global: {
+            lines: 90,
+        },
+    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vn-utils/phone-validate",
-    "version": "0.0.1-rc.3",
+    "version": "0.0.1-rc.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vn-utils/phone-validate",
-            "version": "0.0.1-rc.3",
+            "version": "0.0.1-rc.4",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "build": "rimraf ./lib && tsc",
         "prepare": "npm run build",
         "test": "jest",
+        "test:cov": "jest --coverage",
         "release": "npm version patch && git push --follow-tags",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "git+https://github.com/lehuygiang28/phone-validate.git"
     },
-    "version": "0.0.1-rc.3",
+    "version": "0.0.1-rc.4",
     "description": "A library to validate Vietnamese phone number",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/phone-validate.ts
+++ b/src/phone-validate.ts
@@ -29,17 +29,16 @@ export function getVNPhoneInfo(phoneNumber: string, options?: ValidateOptions): 
         '+84': 12,
     };
 
-    if (!options || !options.startWith.length) {
-        options = {
-            startWith: ['0'],
-        };
+    let { startWith } = options || {};
+    if (!options || !startWith?.length) {
+        startWith = ['0'];
     }
 
     let provider: string | undefined = undefined;
     let isVirtual = false;
 
     if (phoneNumber) {
-        for (const prefix of options.startWith) {
+        for (const prefix of startWith) {
             const length = prefixes[prefix];
             if (!length || phoneNumber.length !== length) {
                 continue;

--- a/src/phone-validate.ts
+++ b/src/phone-validate.ts
@@ -8,8 +8,13 @@ import { PhoneInfo, ValidateOptions } from './types';
  * @param {ValidateOptions} options Optional options
  * @param {('0' | '84' | '+84')[]} [options.startWith] - The allowed prefixes for the phone number. Defaults to ['0'].
  * @returns {PhoneInfo} Information about the phone number
+ * @throws {Error} phoneNumber is invalid
  */
 export function getVNPhoneInfo(phoneNumber: string, options?: ValidateOptions): PhoneInfo {
+    if (!phoneNumber || !phoneNumber.trim() || phoneNumber === null || phoneNumber === undefined) {
+        throw new Error('phoneNumber is invalid');
+    }
+
     /**
      * Prefix and the length of input phone number
      *
@@ -24,7 +29,7 @@ export function getVNPhoneInfo(phoneNumber: string, options?: ValidateOptions): 
         '+84': 12,
     };
 
-    if (!options || !options?.startWith?.length) {
+    if (!options || !options.startWith.length) {
         options = {
             startWith: ['0'],
         };
@@ -69,8 +74,9 @@ export function getVNPhoneInfo(phoneNumber: string, options?: ValidateOptions): 
  * @param {ValidateOptions} [options] - Optional options for validation.
  * @param {('0' | '84' | '+84')[]} [options.startWith] - The allowed prefixes for the phone number. Defaults to ['0'].
  * @return {boolean} Returns true if the phone number is valid, false otherwise.
+ * @throws {Error} phoneNumber is invalid
  */
 export function isValidVNPhone(phoneNumber: string, options?: ValidateOptions): boolean {
-    const phoneInfo = getVNPhoneInfo(phoneNumber, options);
-    return phoneInfo.valid;
+    const info = getVNPhoneInfo(phoneNumber, options);
+    return info.valid;
 }

--- a/src/phone-validate.ts
+++ b/src/phone-validate.ts
@@ -11,7 +11,7 @@ import { PhoneInfo, ValidateOptions } from './types';
  * @throws {Error} phoneNumber is invalid
  */
 export function getVNPhoneInfo(phoneNumber: string, options?: ValidateOptions): PhoneInfo {
-    if (!phoneNumber || !phoneNumber.trim() || phoneNumber === null || phoneNumber === undefined) {
+    if (!phoneNumber || !phoneNumber.trim()) {
         throw new Error('phoneNumber is invalid');
     }
 
@@ -29,8 +29,8 @@ export function getVNPhoneInfo(phoneNumber: string, options?: ValidateOptions): 
         '+84': 12,
     };
 
-    let { startWith } = options || {};
-    if (!options || !startWith?.length) {
+    let { startWith } = options || { startWith: ['0'] };
+    if (!startWith?.length) {
         startWith = ['0'];
     }
 

--- a/test/get-phone-info.test.ts
+++ b/test/get-phone-info.test.ts
@@ -226,6 +226,30 @@ describe('getVNPhoneInfo', () => {
         { provider: 'Mobifone_Local', numbers: ['0891234567', '0891321321'] },
     ].forEach(({ provider, numbers }) => {
         numbers.forEach((number) => {
+            test(`should validate with default options: ${provider} - ${number}`, () => {
+                // Arrange
+                const expectedValid = true;
+
+                // Act
+                const isValid = getVNPhoneInfo(number, { startWith: null as any });
+
+                // Assert
+                expect(isValid.valid).toBe(expectedValid);
+                expect(isValid.virtualProvider).toBe(expectedValid);
+                expect(isValid.provider).toBe(provider);
+                expect(isValid.number).toBe(number);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['0777123456', '0778123456'] },
+        { provider: 'FPT', numbers: ['0775123456', '0775612345'] },
+        { provider: 'Wintel', numbers: ['0551234567', '0559559123'] },
+        { provider: 'Itel', numbers: ['0871234567', '0871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['0891234567', '0891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
             test(`should validate with options is '0': ${provider} - ${number}`, () => {
                 // Arrange
                 const expectedValid = true;

--- a/test/get-phone-info.test.ts
+++ b/test/get-phone-info.test.ts
@@ -1,0 +1,400 @@
+import { getVNPhoneInfo } from '../src';
+import { ValidateOptions } from '../src/types';
+
+describe('getVNPhoneInfo', () => {
+    const options: ValidateOptions = { startWith: ['0', '84', '+84'] };
+    const testCases = [
+        {
+            provider: 'Viettel',
+            numbers: [
+                // 032 - 039
+                '0322174246',
+                '0332174246',
+                '0342174246',
+                '0352174246',
+                '0362174246',
+                '0372174246',
+                '0382174246',
+                '0392174246',
+                '84322174246',
+                '84332174246',
+                '84342174246',
+                '84352174246',
+                '84362174246',
+                '84372174246',
+                '84382174246',
+                '84392174246',
+                '+84322174246',
+                '+84332174246',
+                '+84342174246',
+                '+84352174246',
+                '+84362174246',
+                '+84372174246',
+                '+84382174246',
+                '+84392174246',
+
+                // 096 - 098
+                '0961234567',
+                '0971234567',
+                '0981234567',
+                '84961234567',
+                '84971234567',
+                '84981234567',
+                '+84961234567',
+                '+84971234567',
+                '+84981234567',
+
+                // 086
+                '0862043092',
+                '84862043092',
+                '+84862043092',
+            ],
+        },
+        {
+            provider: 'Vinaphone',
+            numbers: [
+                // 081 - 085
+                '0811234567',
+                '0821234567',
+                '0831234567',
+                '0841234567',
+                '0851234567',
+                '84811234567',
+                '84821234567',
+                '84831234567',
+                '84841234567',
+                '84851234567',
+                '+84811234567',
+                '+84821234567',
+                '+84831234567',
+                '+84841234567',
+                '+84851234567',
+
+                // 088
+                '0881234567',
+                '84881234567',
+                '+84881234567',
+
+                // 091 & 094
+                '0911234567',
+                '0941234567',
+                '84911234567',
+                '84941234567',
+                '+84911234567',
+                '+84941234567',
+            ],
+        },
+        {
+            provider: 'Mobifone',
+            numbers: [
+                '0701234567',
+                '0761234567',
+                '0771234567',
+                '0781234567',
+                '0791234567',
+                '0901234567',
+                '0931234567',
+
+                '84701234567',
+                '84761234567',
+                '84771234567',
+                '84781234567',
+                '84791234567',
+                '84901234567',
+                '84931234567',
+
+                '+84701234567',
+                '+84761234567',
+                '+84771234567',
+                '+84781234567',
+                '+84791234567',
+                '+84901234567',
+                '+84931234567',
+            ],
+        },
+        {
+            provider: 'Vietnamobile',
+            numbers: ['0921234567', '0521234567', '0561234567', '0581234567'],
+        },
+        { provider: 'Gmobile', numbers: ['0991234567', '0591234567'] },
+
+        // Virtual providers
+        { provider: 'Vnsky', numbers: ['0777123456', '0778123456'] },
+        { provider: 'FPT', numbers: ['0775123456', '0775612345'] },
+        { provider: 'Wintel', numbers: ['0551234567', '0559559123'] },
+        { provider: 'Itel', numbers: ['0871234567', '0871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['0891234567', '0891321321'] },
+    ];
+
+    // Test each provider with multiple numbers
+    testCases.forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`validates ${provider} number: ${number}`, () => {
+                // Arrange
+                const expectedValid = true;
+                const expectedProvider = provider;
+
+                // Act
+                const info = getVNPhoneInfo(number, options);
+
+                // Assert
+                expect(info.valid).toBe(expectedValid);
+                expect(info.provider).toBe(expectedProvider);
+                expect(info.number).toBe(number);
+            });
+        });
+    });
+
+    ['', undefined, null, NaN].forEach((invalidNumber) => {
+        test(`should throw Error on invalid number: ${invalidNumber}`, () => {
+            // Act & Assert
+            expect(() => getVNPhoneInfo(invalidNumber as unknown as string, options)).toThrow(
+                'phoneNumber is invalid',
+            );
+        });
+    });
+
+    ['1234567890', 'abc', '00981212', '123'].forEach((wrongNumber) => {
+        test(`should validate wrong number: ${wrongNumber}`, () => {
+            // Arrange
+            const expectedValid = false;
+
+            // Act
+            const isValid = getVNPhoneInfo(wrongNumber, options);
+
+            // Assert
+            expect(isValid.valid).toBe(expectedValid);
+            expect(isValid.provider).toBeUndefined();
+            expect(isValid.number).toBe(wrongNumber);
+            expect(isValid.virtualProvider).toBe(false);
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['0777123456', '0778123456'] },
+        { provider: 'FPT', numbers: ['0775123456', '0775612345'] },
+        { provider: 'Wintel', numbers: ['0551234567', '0559559123'] },
+        { provider: 'Itel', numbers: ['0871234567', '0871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['0891234567', '0891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should validate without options: ${provider} - ${number}`, () => {
+                // Arrange
+                const expectedValid = true;
+
+                // Act
+                const isValid = getVNPhoneInfo(number);
+
+                // Assert
+                expect(isValid.valid).toBe(expectedValid);
+                expect(isValid.provider).toBe(provider);
+                expect(isValid.number).toBe(number);
+                expect(isValid.virtualProvider).toBe(true);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['0777123456', '0778123456'] },
+        { provider: 'FPT', numbers: ['0775123456', '0775612345'] },
+        { provider: 'Wintel', numbers: ['0551234567', '0559559123'] },
+        { provider: 'Itel', numbers: ['0871234567', '0871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['0891234567', '0891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should validate without options: ${provider} - ${number}`, () => {
+                // Arrange
+                const expectedValid = true;
+
+                // Act
+                const isValid = getVNPhoneInfo(number, { startWith: [] });
+
+                // Assert
+                expect(isValid.valid).toBe(expectedValid);
+                expect(isValid.virtualProvider).toBe(expectedValid);
+                expect(isValid.provider).toBe(provider);
+                expect(isValid.number).toBe(number);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['0777123456', '0778123456'] },
+        { provider: 'FPT', numbers: ['0775123456', '0775612345'] },
+        { provider: 'Wintel', numbers: ['0551234567', '0559559123'] },
+        { provider: 'Itel', numbers: ['0871234567', '0871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['0891234567', '0891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should validate with options is '0': ${provider} - ${number}`, () => {
+                // Arrange
+                const expectedValid = true;
+
+                // Act
+                const isValid = getVNPhoneInfo(number, { startWith: ['0'] });
+
+                // Assert
+                expect(isValid.valid).toBe(expectedValid);
+                expect(isValid.virtualProvider).toBe(expectedValid);
+                expect(isValid.provider).toBe(provider);
+                expect(isValid.number).toBe(number);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['0777123456', '0778123456'] },
+        { provider: 'FPT', numbers: ['0775123456', '0775612345'] },
+        { provider: 'Wintel', numbers: ['0551234567', '0559559123'] },
+        { provider: 'Itel', numbers: ['0871234567', '0871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['0891234567', '0891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should not validate with options not match: ${provider} - ${number}`, () => {
+                // Arrange
+                const expectedInvalid = false;
+
+                // Act
+                const isValid = getVNPhoneInfo(number, { startWith: ['84'] });
+
+                // Assert
+                expect(isValid.valid).toBe(expectedInvalid);
+                expect(isValid.virtualProvider).toBe(expectedInvalid);
+                expect(isValid.provider).toBeUndefined();
+                expect(isValid.number).toBe(number);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['0777123456', '0778123456'] },
+        { provider: 'FPT', numbers: ['0775123456', '0775612345'] },
+        { provider: 'Wintel', numbers: ['0551234567', '0559559123'] },
+        { provider: 'Itel', numbers: ['0871234567', '0871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['0891234567', '0891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should not validate with options not match: ${provider} - ${number}`, () => {
+                // Arrange
+                const expectedInvalid = false;
+
+                // Act
+                const isValid = getVNPhoneInfo(number, { startWith: ['+84'] });
+
+                // Assert
+                expect(isValid.valid).toBe(expectedInvalid);
+                expect(isValid.virtualProvider).toBe(expectedInvalid);
+                expect(isValid.provider).toBeUndefined();
+                expect(isValid.number).toBe(number);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['84777123456', '84778123456'] },
+        { provider: 'FPT', numbers: ['84775123456', '84775612345'] },
+        { provider: 'Wintel', numbers: ['84551234567', '84559559123'] },
+        { provider: 'Itel', numbers: ['84871234567', '84871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['84891234567', '84891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should validate with options '84': ${provider} - ${number}`, () => {
+                // Arrange
+                const expectedValid = true;
+
+                // Act
+                const isValid = getVNPhoneInfo(number, { startWith: ['84'] });
+
+                // Assert
+                expect(isValid.valid).toBe(expectedValid);
+                expect(isValid.virtualProvider).toBe(expectedValid);
+                expect(isValid.provider).toBe(provider);
+                expect(isValid.number).toBe(number);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['84777123456', '84778123456'] },
+        { provider: 'FPT', numbers: ['84775123456', '84775612345'] },
+        { provider: 'Wintel', numbers: ['84551234567', '84559559123'] },
+        { provider: 'Itel', numbers: ['84871234567', '84871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['84891234567', '84891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should not validate with options is not '84': ${provider} - ${number}`, () => {
+                // Arrange
+                const expected = false;
+
+                // Act
+                const startWith0 = getVNPhoneInfo(number, { startWith: ['0'] });
+                const startWithPlus84 = getVNPhoneInfo(number, { startWith: ['+84'] });
+
+                // Assert
+                expect(startWith0.valid).toBe(expected);
+                expect(startWith0.virtualProvider).toBe(expected);
+                expect(startWith0.provider).toBeUndefined();
+                expect(startWith0.number).toBe(number);
+
+                expect(startWithPlus84.valid).toBe(expected);
+                expect(startWithPlus84.virtualProvider).toBe(expected);
+                expect(startWithPlus84.provider).toBeUndefined();
+                expect(startWithPlus84.number).toBe(number);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['+84777123456', '+84778123456'] },
+        { provider: 'FPT', numbers: ['+84775123456', '+84775612345'] },
+        { provider: 'Wintel', numbers: ['+84551234567', '+84559559123'] },
+        { provider: 'Itel', numbers: ['+84871234567', '+84871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['+84891234567', '+84891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should validate with options '+84': ${provider} - ${number}`, () => {
+                // Arrange
+                const expectedValid = true;
+
+                // Act
+                const isValid = getVNPhoneInfo(number, { startWith: ['+84'] });
+
+                // Assert
+                expect(isValid.valid).toBe(expectedValid);
+                expect(isValid.virtualProvider).toBe(expectedValid);
+                expect(isValid.provider).toBe(provider);
+                expect(isValid.number).toBe(number);
+            });
+        });
+    });
+
+    [
+        { provider: 'Vnsky', numbers: ['+84777123456', '+84778123456'] },
+        { provider: 'FPT', numbers: ['+84775123456', '+84775612345'] },
+        { provider: 'Wintel', numbers: ['+84551234567', '+84559559123'] },
+        { provider: 'Itel', numbers: ['+84871234567', '+84871321321'] },
+        { provider: 'Mobifone_Local', numbers: ['+84891234567', '+84891321321'] },
+    ].forEach(({ provider, numbers }) => {
+        numbers.forEach((number) => {
+            test(`should not validate with options is not '+84': ${provider} - ${number}`, () => {
+                // Arrange
+                const expected = false;
+
+                // Act
+                const startWith0 = getVNPhoneInfo(number, { startWith: ['0'] });
+                const startWith84 = getVNPhoneInfo(number, { startWith: ['84'] });
+
+                // Assert
+                expect(startWith0.valid).toBe(expected);
+                expect(startWith0.virtualProvider).toBe(expected);
+                expect(startWith0.provider).toBeUndefined();
+                expect(startWith0.number).toBe(number);
+
+                expect(startWith84.valid).toBe(expected);
+                expect(startWith84.virtualProvider).toBe(expected);
+                expect(startWith84.provider).toBeUndefined();
+                expect(startWith84.number).toBe(number);
+            });
+        });
+    });
+});

--- a/test/is-valid.test.ts
+++ b/test/is-valid.test.ts
@@ -1,7 +1,7 @@
-import { getVNPhoneInfo, isValidVNPhone } from '../src';
+import { isValidVNPhone } from '../src';
 import { ValidateOptions } from '../src/types';
 
-describe('Phone number validation', () => {
+describe('isValidVNPhone', () => {
     const options: ValidateOptions = { startWith: ['0', '84', '+84'] };
     const testCases = [
         {
@@ -132,35 +132,36 @@ describe('Phone number validation', () => {
             test(`validates ${provider} number: ${number}`, () => {
                 // Arrange
                 const expectedValid = true;
-                const expectedProvider = provider;
 
                 // Act
-                const info = getVNPhoneInfo(number, options);
                 const isValid = isValidVNPhone(number, options);
 
                 // Assert
-                expect(info.valid).toBe(expectedValid);
-                expect(info.provider).toBe(expectedProvider);
                 expect(isValid).toBe(expectedValid);
             });
         });
     });
 
     // Test invalid numbers
-    ['1234567890', 'abc', '00981212', '123', '', undefined, null, NaN].forEach(
-        (invalidNumber, index) => {
-            test(`invalid number - test case ${index + 1}`, () => {
-                // Arrange
-                const expectedValid = false;
+    ['', undefined, null, NaN].forEach((invalidNumber) => {
+        test(`should throw Error on invalid number: ${invalidNumber}`, () => {
+            // Act & Assert
+            expect(() => isValidVNPhone(invalidNumber as unknown as string, options)).toThrow(
+                'phoneNumber is invalid',
+            );
+        });
+    });
 
-                // Act
-                const info = getVNPhoneInfo(invalidNumber as unknown as string, options);
-                const isValid = isValidVNPhone(invalidNumber as unknown as string, options);
+    ['1234567890', 'abc', '00981212', '123'].forEach((wrongNumber) => {
+        test(`should validate wrong number: ${wrongNumber}`, () => {
+            // Arrange
+            const expectedValid = false;
 
-                // Assert
-                expect(info.valid).toBe(expectedValid);
-                expect(isValid).toBe(expectedValid);
-            });
-        },
-    );
+            // Act
+            const isValid = isValidVNPhone(wrongNumber, options);
+
+            // Assert
+            expect(isValid).toBe(expectedValid);
+        });
+    });
 });


### PR DESCRIPTION
This pull request adds error handling for invalid phone numbers in the `getVNPhoneInfo` function. If the `phoneNumber` parameter is empty, null, or undefined, an error is thrown with the message "phoneNumber is invalid". This change improves the reliability of the phone number validation process.

"Update tests and coverage setup"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new script `test:cov` to run tests with coverage reporting.
  - Introduced a GitHub Actions workflow for test coverage reporting with Coveralls.
  - Updated phone number validation to throw errors for invalid numbers.

- **Bug Fixes**
  - Improved validation logic for Vietnamese phone numbers.

- **Documentation**
  - Updated README with a new package name `@vn-utils/phone-validate` and added a Coveralls badge.

- **Tests**
  - Enhanced test coverage for phone number validation functions.
  - Refactored test cases to ensure accurate validation and error handling.

- **Chores**
  - Added `coverage/` directory to `.eslintignore`, `.gitignore`, `.npmignore`, and `.prettierignore` to exclude coverage reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->